### PR TITLE
feat: define min, mid, max velocity

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -10,4 +10,10 @@ const int ENB_PIN = 4;        // IO4 / GPIO4 / PWM2 / ENB on L298N
 const int FORWARD2_PIN = 16;  // IO16 / GPIO16 / IN3 on L298N
 const int BACKWARD2_PIN = 17; // IO17 / GPIO17 / IN4 on L298N
 
+// Requirement: https://github.com/trippedBit/autonomous-driving-robot-car/issues/17
+// Values 0-255 are possible. Minimum value depends on used motor and friction between wheel and surface.
+const int VELOCITY_MIN = 150;
+const int VELOCITY_MID = 200;
+const int VELOCITY_MAX = 250;
+
 #endif // CONFIGURATION_H

--- a/tests/chassis_motor.cpp
+++ b/tests/chassis_motor.cpp
@@ -1,5 +1,6 @@
 #include "../build/_deps/catch2-src/src/catch2/catch_test_macros.hpp"
 
+#include "../src/configuration.h"
 #include "../src/chassis_motor.h"
 
 // Requirement: https://github.com/trippedBit/autonomous-driving-robot-car/issues/15
@@ -70,4 +71,12 @@ TEST_CASE("Chassis motor direction pin state", "[chassis_motor]")
 
     pinState = motor.getDirectionPinState(static_cast<ChassisMotor::ControlPin>(999));
     REQUIRE(pinState == -1);
+}
+
+// Requirement: https://github.com/trippedBit/autonomous-driving-robot-car/issues/17
+TEST_CASE("Chassis motor velocities", "[chassis_motor]")
+{
+    REQUIRE(VELOCITY_MIN == 150);
+    REQUIRE(VELOCITY_MID == 200);
+    REQUIRE(VELOCITY_MAX == 250);
 }


### PR DESCRIPTION
Adds const data for min, mid and max velocity (PWM values).
Closes #17.